### PR TITLE
Use `const` since local variable is never mutated

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,9 @@
 .{
     .name = "zig-neural-networks",
     .version = "0.1.0",
+    .paths = .{
+        ".",
+    },
     .dependencies = .{
         .zshuffle = .{
             .url = "https://github.com/hmusgrave/zshuffle/archive/8b0154bea5121208826f0f0c864029e8b0e81446.tar.gz",

--- a/src/activation_functions.zig
+++ b/src/activation_functions.zig
@@ -330,7 +330,7 @@ const ActivationTestCase = struct {
 // Cross-check the `activate` function against the `derivative` function to make sure they
 // relate and match up to each other.
 test "Slope check single-input `activation` functions with their derivative" {
-    var test_cases = [_]ActivationTestCase{
+    const test_cases = [_]ActivationTestCase{
         .{
             .activation_function = ActivationFunction{ .relu = .{} },
             .inputs = &[_]f64{ 0.1, 0.2, 0.3, 0.4, 0.5 },
@@ -401,7 +401,7 @@ test "Slope check single-input `activation` functions with their derivative" {
 
     for (test_cases) |test_case| {
         var activation_function = test_case.activation_function;
-        var inputs = test_case.inputs;
+        const inputs = test_case.inputs;
         const input_index = test_case.input_index;
 
         // Estimate the slope of the activation function at the given input
@@ -425,7 +425,7 @@ test "Slope check single-input `activation` functions with their derivative" {
 // Cross-check the `activate` function against the `jacobian_row` function to make sure
 // they relate and match up to each other.
 test "Slope check multi-input `activation` functions with their `jacobian_row`" {
-    var test_cases = [_]ActivationTestCase{
+    const test_cases = [_]ActivationTestCase{
         .{
             .activation_function = ActivationFunction{ .soft_max = .{} },
             .inputs = &[_]f64{ 0.1, 0.2, 0.3, 0.4, 0.5 },
@@ -445,7 +445,7 @@ test "Slope check multi-input `activation` functions with their `jacobian_row`" 
 
     for (test_cases) |test_case| {
         var activation_function = test_case.activation_function;
-        var inputs = test_case.inputs;
+        const inputs = test_case.inputs;
         const row_index = test_case.input_index;
 
         // A Jacobian matrix allows us to take the derivative a function with respect to

--- a/src/cost_functions.zig
+++ b/src/cost_functions.zig
@@ -184,7 +184,7 @@ const LossTestCase = struct {
 // Cross-check the `individual_cost` function against the `individual_derivative`
 // function to make sure they relate and match up to each other.
 test "Slope check cost functions" {
-    var test_cases = [_]LossTestCase{
+    const test_cases = [_]LossTestCase{
         // SquaredError
         .{
             .cost_function = CostFunction{ .squared_error = .{} },

--- a/src/graph_visualization/create_portable_pix_map.zig
+++ b/src/graph_visualization/create_portable_pix_map.zig
@@ -32,7 +32,7 @@ pub fn createPortablePixMap(pixels: []const u24, width: u32, height: u32, alloca
             try pixel_strings.append(pixel_string);
         }
 
-        var pixel_row = try std.mem.join(allocator, "    ", pixel_strings.items);
+        const pixel_row = try std.mem.join(allocator, "    ", pixel_strings.items);
         try pixel_rows.append(pixel_row);
 
         for (pixel_strings.items) |pixel_string| {
@@ -40,7 +40,7 @@ pub fn createPortablePixMap(pixels: []const u24, width: u32, height: u32, alloca
         }
     }
 
-    var pixel_data_string = try std.mem.join(allocator, "\n", pixel_rows.items);
+    const pixel_data_string = try std.mem.join(allocator, "\n", pixel_rows.items);
     defer allocator.free(pixel_data_string);
 
     for (pixel_rows.items) |pixel_row| {

--- a/src/graph_visualization/graph_neural_network.zig
+++ b/src/graph_visualization/graph_neural_network.zig
@@ -63,7 +63,7 @@ pub fn graphNeuralNetwork(
             )) / @as(f64, @floatFromInt(height));
             const predicted_label = try neural_network.classify(&[_]f64{ x, y }, allocator);
 
-            var predicted_label_index: usize = try DataPointType.labelToOneHotIndex(predicted_label);
+            const predicted_label_index: usize = try DataPointType.labelToOneHotIndex(predicted_label);
             if (predicted_label_index > color_pair_map.len - 1) {
                 return error.ColorPairMapNotLargeEnough;
             }
@@ -75,7 +75,7 @@ pub fn graphNeuralNetwork(
 
     // Draw a ball for every training point
     for (training_data_points) |*data_point| {
-        var label_index: usize = try DataPointType.labelToOneHotIndex(data_point.label);
+        const label_index: usize = try DataPointType.labelToOneHotIndex(data_point.label);
         if (label_index > color_pair_map.len - 1) {
             return error.ColorPairMapNotLargeEnough;
         }
@@ -110,7 +110,7 @@ pub fn graphNeuralNetwork(
 
     // Draw a ball for every test point
     for (test_data_points) |*data_point| {
-        var label_index: usize = try DataPointType.labelToOneHotIndex(data_point.label);
+        const label_index: usize = try DataPointType.labelToOneHotIndex(data_point.label);
         if (label_index > color_pair_map.len - 1) {
             return error.ColorPairMapNotLargeEnough;
         }

--- a/src/layers/dense_layer.zig
+++ b/src/layers/dense_layer.zig
@@ -69,22 +69,22 @@ pub const DenseLayer = struct {
         allocator: std.mem.Allocator,
     ) !Self {
         // Initialize the weights
-        var weights: []f64 = try allocator.alloc(f64, num_input_nodes * num_output_nodes);
-        var biases: []f64 = try allocator.alloc(f64, num_output_nodes);
+        const weights: []f64 = try allocator.alloc(f64, num_input_nodes * num_output_nodes);
+        const biases: []f64 = try allocator.alloc(f64, num_output_nodes);
         // We're calling this with the defaults but feel free to call
         // `layer.initializeWeightsAndBiases()` again after the layer is created.
         Self._initializeWeightsAndBiases(weights, biases, .{});
 
         // Create the cost gradients and initialize the values to 0
-        var cost_gradient_weights: []f64 = try allocator.alloc(f64, num_input_nodes * num_output_nodes);
+        const cost_gradient_weights: []f64 = try allocator.alloc(f64, num_input_nodes * num_output_nodes);
         @memset(cost_gradient_weights, 0);
-        var cost_gradient_biases: []f64 = try allocator.alloc(f64, num_output_nodes);
+        const cost_gradient_biases: []f64 = try allocator.alloc(f64, num_output_nodes);
         @memset(cost_gradient_biases, 0);
 
         // Create the velocities and initialize the values to 0
-        var weight_velocities: []f64 = try allocator.alloc(f64, num_input_nodes * num_output_nodes);
+        const weight_velocities: []f64 = try allocator.alloc(f64, num_input_nodes * num_output_nodes);
         @memset(weight_velocities, 0);
-        var bias_velocities: []f64 = try allocator.alloc(f64, num_output_nodes);
+        const bias_velocities: []f64 = try allocator.alloc(f64, num_output_nodes);
         @memset(bias_velocities, 0);
 
         return Self{

--- a/src/neural_network.zig
+++ b/src/neural_network.zig
@@ -81,8 +81,8 @@ pub fn NeuralNetwork(comptime InputDataPointType: type) type {
 
             // We need to keep track of the specific layer types so they can live past
             // this stack context and so we can free them later on `deinit`.
-            var dense_layers = try allocator.alloc(DenseLayer, number_of_dense_layers);
-            var activation_layers = try allocator.alloc(ActivationLayer, number_of_dense_layers);
+            const dense_layers = try allocator.alloc(DenseLayer, number_of_dense_layers);
+            const activation_layers = try allocator.alloc(ActivationLayer, number_of_dense_layers);
 
             // Create the list of layers in the network. Since we treat activation functions
             // as their own layer we create `DenseLayer` followed by `ActivationLayer`.
@@ -193,7 +193,7 @@ pub fn NeuralNetwork(comptime InputDataPointType: type) type {
             inputs: []const f64,
             allocator: std.mem.Allocator,
         ) !DataPointType.LabelType {
-            var outputs = try self.calculateOutputs(inputs, allocator);
+            const outputs = try self.calculateOutputs(inputs, allocator);
             defer allocator.free(outputs);
 
             var max_output = outputs[0];
@@ -232,7 +232,7 @@ pub fn NeuralNetwork(comptime InputDataPointType: type) type {
             data_point: *const DataPointType,
             allocator: std.mem.Allocator,
         ) !f64 {
-            var outputs = try self.calculateOutputs(data_point.inputs, allocator);
+            const outputs = try self.calculateOutputs(data_point.inputs, allocator);
             defer allocator.free(outputs);
 
             return self.cost_function.vector_cost(outputs, &data_point.expected_outputs);
@@ -343,7 +343,7 @@ pub fn NeuralNetwork(comptime InputDataPointType: type) type {
                 var inputs_to_next_layer = data_point.inputs;
                 const layer_outputs_to_free_list = try allocator.alloc([]const f64, self.layers.len);
                 for (self.layers, 0..) |*layer, layer_index| {
-                    var layer_outputs = try layer.forward(inputs_to_next_layer, allocator);
+                    const layer_outputs = try layer.forward(inputs_to_next_layer, allocator);
                     inputs_to_next_layer = layer_outputs;
                     layer_outputs_to_free_list[layer_index] = layer_outputs;
                 }
@@ -383,7 +383,7 @@ pub fn NeuralNetwork(comptime InputDataPointType: type) type {
                     const output_gradient_to_free = output_gradient_for_next_layer;
                     defer allocator.free(output_gradient_to_free);
 
-                    var input_gradient = try layer.backward(
+                    const input_gradient = try layer.backward(
                         output_gradient_for_next_layer,
                         allocator,
                     );


### PR DESCRIPTION
Use `const` since local variable is never mutated

Spotted thanks to trying out Zig `0.12.0-dev.1676+40b8c993f`

Example:
```
src/neural_network.zig:85:17: error: local variable is never mutated
            var activation_layers = try allocator.alloc(ActivationLayer, number_of_dense_layers);
                ^~~~~~~~~~~~~~~~~
src/neural_network.zig:85:17: note: consider using 'const'
```