### PR TITLE
Use better pattern to retrieve items from label EnumMap to avoid dangling pointers

### DIFF
--- a/examples/xor/main.zig
+++ b/examples/xor/main.zig
@@ -28,7 +28,7 @@ const one_hot_xor_label_map = neural_networks.convertLabelEnumToOneHotEncodedEnu
 // The XOR data points
 var xor_data_points = [_]DataPoint{
     // FIXME: Once https://github.com/ziglang/zig/pull/18112 merges and we support a Zig
-    // version, we should use `getPtrConstAssertContains(...)` instead.
+    // version that includes it, we should use `getPtrConstAssertContains(...)` instead.
     DataPoint.init(&[_]f64{ 0, 0 }, one_hot_xor_label_map.getPtrConst(.zero).?),
     DataPoint.init(&[_]f64{ 0, 1 }, one_hot_xor_label_map.getPtrConst(.one).?),
     DataPoint.init(&[_]f64{ 1, 0 }, one_hot_xor_label_map.getPtrConst(.one).?),

--- a/examples/xy_animal_example/main.zig
+++ b/examples/xy_animal_example/main.zig
@@ -39,7 +39,7 @@ const one_hot_animal_label_map = neural_networks.convertLabelEnumToOneHotEncoded
 // https://www.desmos.com/calculator/tkfacez5wt
 var animal_training_data_points = [_]DataPoint{
     // FIXME: Once https://github.com/ziglang/zig/pull/18112 merges and we support a Zig
-    // version, we should use `getPtrConstAssertContains(...)` instead.
+    // version that includes it, we should use `getPtrConstAssertContains(...)` instead.
     DataPoint.init(&[_]f64{ 0.924, 0.166 }, one_hot_animal_label_map.getPtrConst(.goat).?),
     DataPoint.init(&[_]f64{ 0.04, 0.085 }, one_hot_animal_label_map.getPtrConst(.fish).?),
     DataPoint.init(&[_]f64{ 0.352, 0.373 }, one_hot_animal_label_map.getPtrConst(.goat).?),

--- a/src/data_point.zig
+++ b/src/data_point.zig
@@ -87,7 +87,7 @@ pub fn argmaxOneHotEncodedValue(one_hot_outputs: []const f64) !usize {
 /// const example_data_point = DataPoint.init(
 ///     &[_]f64{ 7.2, 3.6, 6.1, 2.5 },
 ///     // FIXME: Once https://github.com/ziglang/zig/pull/18112 merges and we support a Zig
-///     // version, we should use `getPtrConstAssertContains(...)` instead.
+///     // version that includes it, we should use `getPtrConstAssertContains(...)` instead.
 ///     one_hot_iris_flower_label_map.getPtrConst(.virginica).?,
 /// );
 /// ```

--- a/src/tests/data/iris_flower_data.zig
+++ b/src/tests/data/iris_flower_data.zig
@@ -19,7 +19,7 @@ pub const one_hot_iris_flower_label_map = convertLabelEnumToOneHotEncodedEnumMap
 ///  4. Petal width in cm
 pub const iris_flower_data_points = [_]DataPoint{
     // FIXME: Once https://github.com/ziglang/zig/pull/18112 merges and we support a Zig
-    // version, we should use `getPtrConstAssertContains(...)` instead.
+    // version that includes it, we should use `getPtrConstAssertContains(...)` instead.
     DataPoint.init(&[_]f64{ 7.2, 3.6, 6.1, 2.5 }, one_hot_iris_flower_label_map.getPtrConst(.virginica).?),
     DataPoint.init(&[_]f64{ 5.7, 2.8, 4.1, 1.3 }, one_hot_iris_flower_label_map.getPtrConst(.versicolor).?),
     DataPoint.init(&[_]f64{ 6.3, 2.7, 4.9, 1.8 }, one_hot_iris_flower_label_map.getPtrConst(.virginica).?),

--- a/src/tests/data/xor_data.zig
+++ b/src/tests/data/xor_data.zig
@@ -12,7 +12,7 @@ pub const one_hot_xor_label_map = convertLabelEnumToOneHotEncodedEnumMap(XorLabe
 // The XOR data points
 pub const xor_data_points = [_]DataPoint{
     // FIXME: Once https://github.com/ziglang/zig/pull/18112 merges and we support a Zig
-    // version, we should use `getPtrConstAssertContains(...)` instead.
+    // version that includes it, we should use `getPtrConstAssertContains(...)` instead.
     DataPoint.init(&[_]f64{ 0, 0 }, one_hot_xor_label_map.getPtrConst(.zero).?),
     DataPoint.init(&[_]f64{ 0, 1 }, one_hot_xor_label_map.getPtrConst(.one).?),
     DataPoint.init(&[_]f64{ 1, 0 }, one_hot_xor_label_map.getPtrConst(.one).?),


### PR DESCRIPTION
Use better pattern to retrieve items from label EnumMap to avoid dangling pointers

The current method works because it's all done in comptime but if we ever try to retrieve something from the `EnumMap` at runtime `getAssertContains(...)` and then get a pointer to it, it causes dangling pointers (and bugs). Using `getPtrAssertContains(...)` is just a better way to do it using the dedicated functions for this that I didn't know about before (and points to the same value over and over, less memory).

Once https://github.com/ziglang/zig/pull/18112 merges and we support a Zig version that includes it, we can move to `getPtrConstAssertContains(...)`